### PR TITLE
Add sample landing page using unDraw CDN

### DIFF
--- a/undraw-lp.html
+++ b/undraw-lp.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>unDraw CDN LP Sample</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            background-color: #f0f0f0;
+        }
+        .container {
+            text-align: center;
+            padding: 20px;
+            background-color: #ffffff;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+        img {
+            max-width: 100%;
+            height: auto;
+        }
+        h1 {
+            margin-top: 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>サンプルLP</h1>
+        <img src="https://cdn.jsdelivr.net/gh/undraw/undraw@latest/undraw_illustrations/svg/undraw_developer_activity_re_39tg.svg" alt="Developer activity illustration from unDraw">
+        <p>unDrawの素材をCDN経由で使用したLPのサンプルです。</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `undraw-lp.html` demonstrating how to embed an unDraw illustration from a CDN

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891258851b883328d69f4605ac396d4